### PR TITLE
evaluate namespaces recursively, and function namespaces, too

### DIFF
--- a/evalserver.py
+++ b/evalserver.py
@@ -24,11 +24,14 @@ def deaddress(text: str) -> str:
 def get_ns(ns: Mapping[str, Any]) -> dict[str, Any]:
     ret = {}
     for k, v in ns.items():
-        child_ns = None
+        child_ns: Mapping[str, Any] | None = None
         if isinstance(v, type):
             child_ns = v.__dict__
         elif isinstance(v, types.FunctionType):
-            child_ns = v()
+            try:
+                child_ns = v()
+            except Exception as e:
+                child_ns = {"error": "run", "message": repr(e)}
         child: Any
         if child_ns is not None:
             child = get_ns(child_ns)

--- a/test_fuzz_comps.py
+++ b/test_fuzz_comps.py
@@ -236,6 +236,7 @@ def statements():
         st.from_type(ast.Global),
         st.from_type(ast.Expr),
         st.from_type(ast.FunctionDef),
+        st.from_type(ast.Name),
         classes(),
     )
 
@@ -255,7 +256,8 @@ def functions(draw):
     name = draw(identifiers())
     arg_names = draw(st.sets(identifiers(), min_size=0, max_size=3))
     args = ast.arguments(args=[ast.arg(name) for name in arg_names], defaults=[])
-    stmts = draw(st.lists(statements(), min_size=1, max_size=10))
+    stmts = draw(st.lists(statements(), min_size=1, max_size=5))
+    stmts += [ast.Return(ast.Call(ast.Name("locals"), [], []))]
     return ast.FunctionDef(name, args, stmts, [])
 
 
@@ -265,10 +267,7 @@ st.register_type_strategy(ast.FunctionDef, functions())
 def module_level_statements():
     # require top-level class or function; plain module-level comprehensions are
     # not very interesting in terms of finding scoping bugs
-    return st.one_of(
-        st.from_type(ast.ClassDef),
-        st.from_type(ast.FunctionDef)
-    )
+    return st.one_of(st.from_type(ast.ClassDef), st.from_type(ast.FunctionDef))
 
 
 st.register_type_strategy(


### PR DESCRIPTION
This recursively finds functions and classes from the top-level namespace and evaluates both.

For functions we do this by inserting a `return locals()` as the last statement in every function, so we can call it to get its namespace.