### PR TITLE
fixes to filter out fewer examples

### DIFF
--- a/test_fuzz_comps.py
+++ b/test_fuzz_comps.py
@@ -7,7 +7,7 @@ from astor import to_source  # type: ignore
 import time
 
 import evalserver
-from hypothesis import given, settings, strategies as st, target, HealthCheck
+from hypothesis import event, given, settings, strategies as st, target, HealthCheck
 
 
 @pytest.fixture(scope="module")
@@ -44,13 +44,12 @@ def evalserver_client(request, logfile):
             proc.wait()
 
 
-def record_targets(tree: ast.Module) -> ast.Module:
-    nodes = list(ast.walk(tree))
+def record_targets(tree: ast.Module) -> str:
     num_lambdas = 0
     num_listcomps = 0
     num_classes = 0
     num_functions = 0
-    for n in nodes:
+    for n in ast.walk(tree):
         if isinstance(n, ast.Lambda):
             num_lambdas += 1
         elif isinstance(n, ast.ListComp):
@@ -70,15 +69,12 @@ def record_targets(tree: ast.Module) -> ast.Module:
     return to_source(tree)
 
 
-def has_listcomp(tree: ast.Module) -> bool:
-    return bool(any(isinstance(n, ast.ListComp) for n in ast.walk(tree)))
-
-
 def compilable(tree: ast.Module) -> bool:
     codestr = to_source(tree)
     try:
         compile(codestr, "<string>", "exec")
     except Exception:
+        event("not compilable")
         return False
     return True
 
@@ -94,28 +90,6 @@ st.register_type_strategy(ast.Name, st.builds(ast.Name, identifiers()))
 st.register_type_strategy(
     ast.Constant, st.builds(ast.Constant, st.integers(min_value=1, max_value=10))
 )
-st.register_type_strategy(
-    ast.List,
-    st.builds(
-        ast.List,
-        st.lists(
-            st.one_of(st.from_type(ast.Name), st.from_type(ast.Constant)),
-            min_size=0,
-            max_size=3,
-        ),
-    ),
-)
-st.register_type_strategy(
-    ast.Tuple,
-    st.builds(
-        ast.Tuple,
-        st.lists(
-            st.one_of(st.from_type(ast.Name), st.from_type(ast.Constant)),
-            min_size=0,
-            max_size=3,
-        ),
-    ),
-)
 
 
 def target_expr():
@@ -128,9 +102,8 @@ def target_expr():
 def subscript_value_expr():
     return st.one_of(
         st.from_type(ast.Name),
-        listcomps(),
-        st.from_type(ast.Lambda),
         st.from_type(ast.Subscript),
+        listcomps(),
     )
 
 
@@ -138,21 +111,19 @@ def value_expr():
     return st.one_of(
         st.from_type(ast.Constant),
         st.from_type(ast.Name),
-        listcomps(),
-        st.from_type(ast.Lambda),
         st.from_type(ast.Subscript),
         st.from_type(ast.NamedExpr),
+        st.from_type(ast.Lambda),
         st.from_type(ast.List),
-        st.from_type(ast.Tuple),
+        listcomps(),
     )
 
 
 def iterable_expr():
     return st.one_of(
-        st.from_type(ast.List),
-        st.from_type(ast.Tuple),
         st.from_type(ast.Name),
         st.from_type(ast.Subscript),
+        st.from_type(ast.List),
         listcomps(),
     )
 
@@ -181,7 +152,7 @@ st.register_type_strategy(ast.Subscript, subscripts())
 @st.composite
 def lambdas(draw):
     body = draw(value_expr())
-    arg_names = draw(st.sets(identifiers(), min_size=0, max_size=3))
+    arg_names = set(draw(st.lists(identifiers(), min_size=0, max_size=2)))
     args = ast.arguments(args=[ast.arg(name) for name in arg_names], defaults=[])
     return ast.Lambda(args, body)
 
@@ -212,19 +183,16 @@ st.register_type_strategy(
     ast.List, st.builds(ast.List, st.lists(value_expr(), min_size=0, max_size=3))
 )
 st.register_type_strategy(
-    ast.Tuple, st.builds(ast.Tuple, st.lists(value_expr(), min_size=0, max_size=3))
-)
-st.register_type_strategy(
     ast.Expr,
     st.builds(ast.Expr, value_expr()),
 )
 st.register_type_strategy(
     ast.Global,
-    st.builds(ast.Global, st.lists(identifiers(), min_size=1, max_size=3)),
+    st.builds(ast.Global, st.sets(identifiers(), min_size=1, max_size=1)),
 )
 st.register_type_strategy(
     ast.Nonlocal,
-    st.builds(ast.Nonlocal, st.lists(identifiers(), min_size=1, max_size=3)),
+    st.builds(ast.Nonlocal, st.sets(identifiers(), min_size=1, max_size=1)),
 )
 
 
@@ -241,11 +209,8 @@ st.register_type_strategy(ast.Assign, assigns())
 def statements():
     return st.one_of(
         st.from_type(ast.Assign),
-        st.from_type(ast.Nonlocal),
-        st.from_type(ast.Global),
         st.from_type(ast.Expr),
         st.from_type(ast.FunctionDef),
-        st.from_type(ast.Name),
         classes(),
     )
 
@@ -253,7 +218,11 @@ def statements():
 @st.composite
 def classes(draw):
     name = draw(identifiers())
-    stmts = draw(st.lists(statements(), min_size=1, max_size=10))
+    global_stmts = draw(st.lists(st.from_type(ast.Global), min_size=0, max_size=1))
+    pre_stmts = draw(st.lists(statements(), min_size=0, max_size=3))
+    comps = draw(st.lists(st.builds(ast.Expr, listcomps()), min_size=1, max_size=3))
+    post_stmts = draw(st.lists(statements(), min_size=0, max_size=3))
+    stmts = global_stmts + pre_stmts + comps + post_stmts
     return ast.ClassDef(name, body=stmts, decorator_list=[], bases=[])
 
 
@@ -263,10 +232,19 @@ st.register_type_strategy(ast.ClassDef, classes())
 @st.composite
 def functions(draw):
     name = draw(identifiers())
-    arg_names = draw(st.sets(identifiers(), min_size=0, max_size=2))
+    arg_names = set(draw(st.lists(identifiers(), min_size=0, max_size=2)))
     args = ast.arguments(args=[ast.arg(name) for name in arg_names], defaults=[])
-    stmts = draw(st.lists(statements(), min_size=1, max_size=5))
-    stmts += [ast.Return(ast.Call(ast.Name("locals"), [], []))]
+    global_stmts = draw(st.lists(st.from_type(ast.Global), min_size=0, max_size=1))
+    pre_stmts = draw(st.lists(statements(), min_size=0, max_size=3))
+    comps = draw(st.lists(st.builds(ast.Expr, listcomps()), min_size=1, max_size=3))
+    post_stmts = draw(st.lists(statements(), min_size=0, max_size=3))
+    stmts = (
+        global_stmts
+        + pre_stmts
+        + comps
+        + post_stmts
+        + [ast.Return(ast.Call(ast.Name("locals"), [], []))]
+    )
     return ast.FunctionDef(name, args, stmts, [])
 
 
@@ -288,7 +266,6 @@ st.register_type_strategy(
 def modules():
     return (
         st.from_type(ast.Module)
-        .filter(has_listcomp)
         .filter(compilable)
         .map(record_targets)
     )

--- a/test_fuzz_comps.py
+++ b/test_fuzz_comps.py
@@ -107,6 +107,12 @@ def subscript_value_expr():
     )
 
 
+def lists():
+    return st.builds(
+        ast.List, st.lists(st.deferred(value_expr), min_size=0, max_size=3)
+    )
+
+
 def value_expr():
     return st.one_of(
         st.from_type(ast.Constant),
@@ -114,7 +120,7 @@ def value_expr():
         st.from_type(ast.Subscript),
         st.from_type(ast.NamedExpr),
         st.from_type(ast.Lambda),
-        st.from_type(ast.List),
+        lists(),
         listcomps(),
     )
 
@@ -123,7 +129,7 @@ def iterable_expr():
     return st.one_of(
         st.from_type(ast.Name),
         st.from_type(ast.Subscript),
-        st.from_type(ast.List),
+        lists(),
         listcomps(),
     )
 
@@ -179,9 +185,7 @@ def listcomps(draw):
 
 
 st.register_type_strategy(ast.ListComp, listcomps())
-st.register_type_strategy(
-    ast.List, st.builds(ast.List, st.lists(value_expr(), min_size=0, max_size=3))
-)
+st.register_type_strategy(ast.List, lists())
 st.register_type_strategy(
     ast.Expr,
     st.builds(ast.Expr, value_expr()),
@@ -264,16 +268,12 @@ st.register_type_strategy(
 
 
 def modules():
-    return (
-        st.from_type(ast.Module)
-        .filter(compilable)
-        .map(record_targets)
-    )
+    return st.from_type(ast.Module).filter(compilable).map(record_targets)
 
 
 @given(modules())
 @settings(
-    max_examples=100_000,
+    max_examples=100,
     deadline=None,
     suppress_health_check=[HealthCheck.too_slow, HealthCheck.filter_too_much],
 )


### PR DESCRIPTION
Made some fixes to generate fewer invalid examples and thus do less rejection sampling. Specific changes and why I made them:

* I removed the initial "name and constant only" List and Tuple strategies. These were only added to avoid forward-reference problems, but I'm not seeing those issues now. "Name and constant only" lists and tuples aren't really interesting, so if we don't need them, let's not have those strategies.
* I updated the ClassDef and FunctionDef strategies to always generate at least one listcomp in the body. This way we don't have to filter for no-listcomps.
* I re-ordered all the `one_of` strategies to be ordered from simpler to more complex sub-strategies. This is recommended by the Hypothesis docs to aid in simplification of examples.
* I removed tuples entirely for simplicity; for our purposes I don't think they give us anything interesting that lists don't.
* Instead of generating sets of identifiers (which led to a lot of rejections from drawing repeat values) I draw lists of identifiers instead and then convert them to a set. This will bias away from two-argument functions/lambdas and towards one-argument ones, but I think that's fine. (If it's a problem we could draw a list of max_size 3 or 4 instead of 2, and then convert it to a set.)
* I removed direct generation of `Name` as a statement; this was just a bug and led to uncompilable code due to lacking newlines. `Name` is an expression and must be nested under `Expr`, which is already a valid statement.
* I removed `nonlocal` statements entirely. They just force an assigned var to be a free var, but I don't think that's especially interesting, since we can easily get free vars by just not assigning to them. And invalid nonlocal statements generate a lot of non-compilable examples.
* Instead of generating `global` statements anywhere (where they can become invalid because of prior assignment), I generate 0 or 1 `global` statements at the top of the function or class body, and nowhere else.