### PR TITLE
Shrink to leaf nodes

### DIFF
--- a/test_fuzz_comps.py
+++ b/test_fuzz_comps.py
@@ -149,9 +149,9 @@ def value_expr():
 
 def iterable_expr():
     return st.one_of(
+        st.from_type(ast.Name),
         st.from_type(ast.List),
         st.from_type(ast.Tuple),
-        st.from_type(ast.Name),
         st.from_type(ast.Subscript),
         listcomps(),
     )
@@ -240,12 +240,12 @@ st.register_type_strategy(ast.Assign, assigns())
 
 def statements():
     return st.one_of(
+        st.from_type(ast.Name),
         st.from_type(ast.Assign),
         st.from_type(ast.Nonlocal),
         st.from_type(ast.Global),
         st.from_type(ast.Expr),
         st.from_type(ast.FunctionDef),
-        st.from_type(ast.Name),
         classes(),
     )
 


### PR DESCRIPTION
This will shrink more efficiently, but the engine will also exploit it to get out of very deeply nested structures by inserting runs of "choose simplest thing" occasionally.  If that leads to a deep tree instead of a leaf, you might get perf problems!

(haven't actually tested perf here but it's worth trying)